### PR TITLE
Fixed 2 format semicollon bugs on save.

### DIFF
--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -3,7 +3,11 @@ export default class MumpsFormattingHelpProvider {
 	/*eslint class-methods-use-this: 0*/
 	provideDocumentFormattingEdits(document: vscode.TextDocument) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = 0; i < document.lineCount; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		for (let i = 0; i < numLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}

--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -3,11 +3,7 @@ export default class MumpsFormattingHelpProvider {
 	/*eslint class-methods-use-this: 0*/
 	provideDocumentFormattingEdits(document: vscode.TextDocument) {
 		const textEdits: vscode.TextEdit[] = []
-		let numLines = document.lineCount;
-		if (document.lineAt(numLines-1).text === ""){
-			numLines = numLines - 1
-		}
-		for (let i = 0; i < numLines; i++) {
+		for (let i = 0; i < document.lineCount; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -15,15 +11,7 @@ export default class MumpsFormattingHelpProvider {
 	}
 	provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range) {
 		const textEdits: vscode.TextEdit[] = []
-		let numLines = document.lineCount;
-		if (document.lineAt(numLines-1).text === ""){
-			numLines = numLines - 1
-		}
-		let extraLines = 0;
-		if (range.end.line >= numLines){
-			extraLines = range.end.line-numLines
-		}
-		for (let i = range.start.line; i <= range.end.line - extraLines; i++) {
+		for (let i = range.start.line; i <= range.end.line; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -35,7 +23,7 @@ function formatDocumentLine(line: string, lineNumber: number, textEdits) {
 	if (emptyLine.length === 0) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, 0), "\t;"))
 	}
-	if ((line.endsWith(". ") || line.endsWith(".")) && !(line.includes(";"))) {
+	if (line.endsWith(". ") || line.endsWith(".")) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";"))
 	}
 	if (line.startsWith(" ")) {

--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -3,7 +3,11 @@ export default class MumpsFormattingHelpProvider {
 	/*eslint class-methods-use-this: 0*/
 	provideDocumentFormattingEdits(document: vscode.TextDocument) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = 0; i < document.lineCount; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		for (let i = 0; i < numLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -11,7 +15,15 @@ export default class MumpsFormattingHelpProvider {
 	}
 	provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = range.start.line; i <= range.end.line; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		let extraLines = 0;
+		if (range.end.line >= numLines){
+			extraLines = range.end.line-numLines
+		}
+		for (let i = range.start.line; i <= range.end.line - extraLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -23,8 +35,8 @@ function formatDocumentLine(line: string, lineNumber: number, textEdits) {
 	if (emptyLine.length === 0) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, 0), "\t;"))
 	}
-	if (line.endsWith(". ") || line.endsWith(".")) {
-		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";"))
+	if ((line.endsWith(". ") || line.endsWith(".")) && !(line.includes(";"))) {
+		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";;;;"))
 	}
 	if (line.startsWith(" ")) {
 		let endSpace: number;

--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -3,7 +3,11 @@ export default class MumpsFormattingHelpProvider {
 	/*eslint class-methods-use-this: 0*/
 	provideDocumentFormattingEdits(document: vscode.TextDocument) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = 0; i < document.lineCount; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		for (let i = 0; i < numLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -11,7 +15,15 @@ export default class MumpsFormattingHelpProvider {
 	}
 	provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = range.start.line; i <= range.end.line; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		let extraLines = 0;
+		if (range.end.line >= numLines){
+			extraLines = range.end.line-numLines
+		}
+		for (let i = range.start.line; i <= range.end.line - extraLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -23,7 +35,7 @@ function formatDocumentLine(line: string, lineNumber: number, textEdits) {
 	if (emptyLine.length === 0) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, 0), "\t;"))
 	}
-	if (line.endsWith(". ") || line.endsWith(".")) {
+	if ((line.endsWith(". ") || line.endsWith(".")) && !(line.includes(";"))) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";"))
 	}
 	if (line.startsWith(" ")) {

--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -15,7 +15,15 @@ export default class MumpsFormattingHelpProvider {
 	}
 	provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range) {
 		const textEdits: vscode.TextEdit[] = []
-		for (let i = range.start.line; i <= range.end.line; i++) {
+		let numLines = document.lineCount;
+		if (document.lineAt(numLines-1).text === ""){
+			numLines = numLines - 1
+		}
+		let extraLines = 0;
+		if (range.end.line >= numLines){
+			extraLines = range.end.line-numLines
+		}
+		for (let i = range.start.line; i <= range.end.line - extraLines; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -27,7 +35,7 @@ function formatDocumentLine(line: string, lineNumber: number, textEdits) {
 	if (emptyLine.length === 0) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, 0), "\t;"))
 	}
-	if (line.endsWith(". ") || line.endsWith(".")) {
+	if ((line.endsWith(". ") || line.endsWith(".")) && !(line.includes(";"))) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";"))
 	}
 	if (line.startsWith(" ")) {

--- a/src/mumpsFormattingHelpProvider.ts
+++ b/src/mumpsFormattingHelpProvider.ts
@@ -3,11 +3,7 @@ export default class MumpsFormattingHelpProvider {
 	/*eslint class-methods-use-this: 0*/
 	provideDocumentFormattingEdits(document: vscode.TextDocument) {
 		const textEdits: vscode.TextEdit[] = []
-		let numLines = document.lineCount;
-		if (document.lineAt(numLines-1).text === ""){
-			numLines = numLines - 1
-		}
-		for (let i = 0; i < numLines; i++) {
+		for (let i = 0; i < document.lineCount; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -15,15 +11,7 @@ export default class MumpsFormattingHelpProvider {
 	}
 	provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range) {
 		const textEdits: vscode.TextEdit[] = []
-		let numLines = document.lineCount;
-		if (document.lineAt(numLines-1).text === ""){
-			numLines = numLines - 1
-		}
-		let extraLines = 0;
-		if (range.end.line >= numLines){
-			extraLines = range.end.line-numLines
-		}
-		for (let i = range.start.line; i <= range.end.line - extraLines; i++) {
+		for (let i = range.start.line; i <= range.end.line; i++) {
 			const line = document.lineAt(i).text;
 			formatDocumentLine(line, i, textEdits);
 		}
@@ -35,8 +23,8 @@ function formatDocumentLine(line: string, lineNumber: number, textEdits) {
 	if (emptyLine.length === 0) {
 		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, 0), "\t;"))
 	}
-	if ((line.endsWith(". ") || line.endsWith(".")) && !(line.includes(";"))) {
-		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";;;;"))
+	if (line.endsWith(". ") || line.endsWith(".")) {
+		textEdits.push(vscode.TextEdit.insert(new vscode.Position(lineNumber, line.length), ";"))
 	}
 	if (line.startsWith(" ")) {
 		let endSpace: number;


### PR DESCRIPTION
1 in M it is valid to have a newline at the end of a file, the extension will no longer add a comment after the final newline in the file if that final line is empty.

2 extension would add a semicolon to the end of a line that ended in a period symbol even if the line was a comment, it now no longer adds a semicolon to the end of comment lines.